### PR TITLE
TECH-1432: Move shortcuts-inline.css back to assets

### DIFF
--- a/src/main/resources/css/shortcuts-inline.css
+++ b/src/main/resources/css/shortcuts-inline.css
@@ -1,0 +1,89 @@
+/*shortcuts*/
+
+ div.shortcuts-inline {
+    display: inline;
+    float: right;
+    text-align: right;
+    font-size: 85%;
+    line-height: 2em;
+    line-height: normal;
+    padding: 10px;
+}
+
+ div.shortcuts-inline a,
+ div.shortcuts-inline a:link,
+ div.shortcuts-inline a:visited {
+    color: #333333;
+    text-decoration: none;
+    background: none;
+}
+
+ div.shortcuts-inline a:hover,
+ div.shortcuts-inline a:active {
+    color: #333333;
+    text-decoration: underline;
+    background: none;
+}
+
+ .shortcuts-inline ul {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+}
+
+ .shortcuts-inline li {
+    display: inline;
+    padding: 0 5px;
+    background: none;
+}
+
+ .shortcuts-inline li.shortcuts-print {
+    background: transparent url( img/shortcuts-print.png ) no-repeat 0% 50%;
+    padding-left: 16px;
+}
+
+ .shortcuts-inline li.shortcuts-typoincrease {
+    background: transparent url( img/shortcuts-typoincrease.png ) no-repeat 0% 50%;
+    padding-left: 16px;
+}
+
+ .shortcuts-inline li.shortcuts-typoreduce {
+    background: transparent url( img/shortcuts-typoreduce.png ) no-repeat 0% 50%;
+    padding-left: 16px;
+}
+
+ .shortcuts-inline li.shortcuts-home {
+    background: transparent url( img/shortcuts-home.png ) no-repeat 0% 50%;
+    padding-left: 16px;
+}
+
+ .shortcuts-inline li.shortcuts-contact {
+    background: transparent url( img/shortcuts-contact.png ) no-repeat 0% 50%;
+    padding-left: 16px;
+}
+
+ .shortcuts-inline li.shortcuts-sitemap {
+    background: transparent url( img/shortcuts-sitemap.png ) no-repeat 0% 50%;
+    padding-left: 16px;
+}
+
+ .shortcuts-inline li.shortcuts-mysettings {
+    background: transparent url( img/shortcuts-mysettings.png ) no-repeat 0% 50%;
+    padding-left: 16px;
+}
+ .shortcuts-inline li.shortcuts-contribute {
+    background: transparent url( img/shortcuts-contribute.png ) no-repeat 0% 50%;
+    padding-left: 16px;
+}
+ .shortcuts-inline li.shortcuts-edit {
+    background: transparent url( img/shortcuts-edit.png ) no-repeat 0% 50%;
+    padding-left: 16px;
+}
+
+ .shortcuts-inline li.shortcuts-login {
+    background-color: #eaeaea ;
+	-moz-border-radius: 3px;
+	-webkit-border-radius: 3px;
+	border-radius: 3px;
+	border:1px solid #ccc;
+}


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

  https://jira.jahia.org/browse/TECH-1432

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

Move css from default module back to assets module. CSS still used in core notification/externalize.html
