### PR TITLE
BACKLOG-23578: updated the release workflow to use the reusable workflow [skip ci]

### DIFF
--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -7,74 +7,8 @@ on:
     types: [prereleased]
 
 jobs:
-  on-release:
-    runs-on: ubuntu-latest
-
-    # The cimg-mvn-cache is an image containing a .m2 folder warmed-up
-    # with common Jahia dependencies. Using this prevents maven from
-    # downloading the entire world when building.
-    # More on https://github.com/Jahia/cimg-mvn-cache
-    container:
-      image: jahia/cimg-mvn-cache:ga_cimg_openjdk_11.0.20-node
-      credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
-
-    steps:
-      # Providing the SSH PRIVATE of a user part of an admin group
-      # is necessary to bypass PR checks
-      - uses: actions/checkout@v4
-        with:
-          ssh-key: ${{ secrets.GH_SSH_PRIVATE_KEY_JAHIACI }}
-
-      # Setting up the SSH agent to be able to commit back to the repository
-      # https://github.com/webfactory/ssh-agent
-      - uses: webfactory/ssh-agent@v0.7.0
-        with:
-          ssh-private-key: ${{ secrets.GH_SSH_PRIVATE_KEY_JAHIACI }}
-
-      - uses: jahia/jahia-modules-action/release@v2
-        name: Release Module
-        with:
-          github_slug: Jahia/assets
-          primary_release_branch: master
-          release_id: ${{ github.event.release.id }}
-          release_version: ${{ github.event.release.tag_name }}
-          github_api_token: ${{ secrets.GH_API_TOKEN }}
-          nexus_username: ${{ secrets.NEXUS_USERNAME }}
-          nexus_password: ${{ secrets.NEXUS_PASSWORD }}
-
-      - uses: jahia/jahia-modules-action/update-signature@v2
-        with:
-          nexus_username: ${{ secrets.NEXUS_USERNAME }}
-          nexus_password: ${{ secrets.NEXUS_PASSWORD }}
-          nexus_enterprise_releases_url: ${{ secrets.NEXUS_ENTERPRISE_RELEASES_URL }}
-          force_signature: true
-
-      - uses: jahia/jahia-modules-action/release-publication@v2
-        name: Publish Module
-        with:
-          module_id: assets
-          release_version: ${{ github.event.release.tag_name }}
-          nexus_username: ${{ secrets.NEXUS_USERNAME }}
-          nexus_password: ${{ secrets.NEXUS_PASSWORD }}
-
-      # Tmate only starts if any of the previous steps fails.
-      # Be careful since it also means that if a step fails the workflow will
-      # keep running until it reaches the timeout
-      - name: Setup tmate session
-        if: ${{ failure() }}
-        uses: mxschmitt/action-tmate@v3
-        timeout-minutes: 15
-
-  sbom:
-    name: SBOM processing
-    needs: on-release
-    runs-on: ubuntu-latest
-    container:
-      image: cyclonedx/cyclonedx-cli:0.24.2   
-    steps:
-      - uses: jahia/jahia-modules-action/sbom-processing@v2
-        with:
-          dependencytrack_hostname: ${{ vars.DEPENDENCYTRACK_HOSTNAME }}
-          dependencytrack_apikey: ${{ secrets.DEPENDENCYTRACK_APIKEY }}
+  release-module:
+    uses: Jahia/jahia-modules-action/.github/workflows/release-module.yml@v2
+    secrets: inherit 
+    with:
+      primary_release_branch: "master"


### PR DESCRIPTION
Since the slack notification was missing, I went ahead and replaced the entire workflow with the reusable one.

https://jira.jahia.org/browse/BACKLOG-23578