### PR TITLE
BACKLOG-23578: Added credentials to staging repository

### DIFF
--- a/.github/maven.settings.xml
+++ b/.github/maven.settings.xml
@@ -47,6 +47,11 @@
             <password>${env.NEXUS_PASSWORD}</password>
         </server>
         <server>
+            <id>staging-repository</id>
+            <username>${env.NEXUS_USERNAME}</username>
+            <password>${env.NEXUS_PASSWORD}</password>
+        </server>        
+        <server>
             <id>jahia-internal</id>
             <username>${env.NEXUS_USERNAME}</username>
             <password>${env.NEXUS_PASSWORD}</password>


### PR DESCRIPTION
https://jira.jahia.org/browse/BACKLOG-23578

```
Error: [ERROR] Failed to execute goal org.sonatype.plugins:nexus-staging-maven-plugin:1.5.1:deploy (injected-nexus-deploy) on project assets: Server credentials with ID "staging-repository" not found! -> [Help 1]
Error: [ERROR] 
Error: [ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
Error: [ERROR] Re-run Maven using the -X switch to enable full debug logging.
Error: [ERROR] 
Error: [ERROR] For more information about the errors and possible solutions, please read the following articles:
Error: [ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException
```